### PR TITLE
updates "Swaziland" country name to "Eswatini"

### DIFF
--- a/src/domain/countries.ts
+++ b/src/domain/countries.ts
@@ -774,7 +774,7 @@ export const countries: Country[] = [
     name: "El Salvador",
   },
   { code: "SY", latitude: 34.802075, longitude: 38.996815, name: "Syria" },
-  { code: "SZ", latitude: -26.522503, longitude: 31.465866, name: "Swaziland" },
+  { code: "SZ", latitude: -26.522503, longitude: 31.465866, name: "Eswatini" },
   {
     code: "TC",
     latitude: 21.694025,


### PR DESCRIPTION
This country changed its name in 2018. The main OEC site uses the correct name for the country profile, but this old country lookup needs to be updated (currently, users cannot search for "Eswatini" if that is the correct answer)