### PR TITLE
Add an option to reveal imprecise distance information

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { ToastContainer, Flip } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import { Game } from "./components/Game";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Infos } from "./components/panels/Infos";
 import { useTranslation } from "react-i18next";
 import { InfosFr } from "./components/panels/InfosFr";
@@ -17,14 +17,6 @@ function App() {
   const [statsOpen, setStatsOpen] = useState(false);
 
   const [settingsData, updateSettings] = useSettings();
-
-  useEffect(() => {
-    if (settingsData.theme === "dark") {
-      document.documentElement.classList.add("dark");
-    } else {
-      document.documentElement.classList.remove("dark");
-    }
-  }, [settingsData.theme]);
 
   return (
     <>
@@ -110,7 +102,7 @@ function App() {
                 <path d="M2 11a1 1 0 011-1h2a1 1 0 011 1v5a1 1 0 01-1 1H3a1 1 0 01-1-1v-5zM8 7a1 1 0 011-1h2a1 1 0 011 1v9a1 1 0 01-1 1H9a1 1 0 01-1-1V7zM14 4a1 1 0 011-1h2a1 1 0 011 1v12a1 1 0 01-1 1h-2a1 1 0 01-1-1V4z" />
               </svg>
             </button>
-            {/* <button
+            <button
               className="ml-3 text-xl"
               type="button"
               onClick={() => setSettingsOpen(true)}
@@ -127,7 +119,7 @@ function App() {
                   clipRule="evenodd"
                 />
               </svg>
-            </button> */}
+            </button>
           </header>
           <Game settingsData={settingsData} />
           <footer className="flex justify-center text-sm mt-8 mb-1">

--- a/src/components/GuessRow.tsx
+++ b/src/components/GuessRow.tsx
@@ -2,6 +2,7 @@ import {
   computeProximityPercent,
   Direction,
   formatDistance,
+  formatFuzzyDistance,
   generateSquareCharacters,
 } from "../domain/geography";
 import { Guess } from "../domain/guess";
@@ -57,7 +58,7 @@ export function GuessRow({
   countryInputRef,
   isAprilFools = false,
 }: GuessRowProps) {
-  const { distanceUnit, theme } = settingsData;
+  const { distanceUnit, theme, fuzzyDistance } = settingsData;
   const proximity = guess != null ? computeProximityPercent(guess.distance) : 0;
   const squares = generateSquareCharacters(proximity, theme);
 
@@ -111,13 +112,16 @@ export function GuessRow({
               </div>
             ))}
           </div>
-          <div className="border-2 h-8 col-span-1 animate-reveal">
-            <CountUp
-              end={isAprilFools ? 100 : proximity}
-              suffix="%"
-              duration={(SQUARE_ANIMATION_LENGTH * 5) / 1000}
-            />
-          </div>
+
+          {!fuzzyDistance && (
+            <div className="border-2 h-8 col-span-1 animate-reveal">
+              <CountUp
+                end={isAprilFools ? 100 : proximity}
+                suffix="%"
+                duration={(SQUARE_ANIMATION_LENGTH * 5) / 1000}
+              />
+            </div>
+          )}
         </>
       );
     case "ENDED":
@@ -125,9 +129,9 @@ export function GuessRow({
         <>
           <div
             className={
-              guess?.distance === 0
-                ? "bg-oec-yellow rounded-lg flex items-center h-8 col-span-3 animate-reveal pl-2"
-                : "bg-gray-200 rounded-lg flex items-center h-8 col-span-3 animate-reveal pl-2"
+              "rounded-lg flex items-center h-8 animate-reveal pl-2" +
+              (guess?.distance === 0 ? " bg-oec-yellow" : " bg-gray-200") +
+              (fuzzyDistance ? " col-span-4" : " col-span-3")
             }
           >
             <p className="text-ellipsis overflow-hidden whitespace-nowrap">
@@ -143,6 +147,8 @@ export function GuessRow({
           >
             {guess && isAprilFools
               ? "⁇"
+              : guess && fuzzyDistance
+              ? formatFuzzyDistance(guess.distance)
               : guess
               ? formatDistance(guess.distance, distanceUnit)
               : null}
@@ -162,17 +168,19 @@ export function GuessRow({
               ? DIRECTION_ARROWS[guess.direction]
               : null}
           </div>
-          <div
-            className={
-              guess?.distance === 0
-                ? "bg-oec-yellow rounded-lg flex items-center justify-center h-8 col-span-1 animate-reveal animate-pop"
-                : "bg-gray-200 rounded-lg flex items-center justify-center h-8 col-span-1 animate-reveal animate-pop"
-            }
-          >
-            {isAprilFools
-              ? DIRECTION_ARROWS_APRIL_FOOLS[index]
-              : `${proximity}%`}
-          </div>
+          {!fuzzyDistance && (
+            <div
+              className={
+                guess?.distance === 0
+                  ? "bg-oec-yellow rounded-lg flex items-center justify-center h-8 col-span-1 animate-reveal animate-pop"
+                  : "bg-gray-200 rounded-lg flex items-center justify-center h-8 col-span-1 animate-reveal animate-pop"
+              }
+            >
+              {isAprilFools
+                ? DIRECTION_ARROWS_APRIL_FOOLS[index]
+                : `${proximity}%`}
+            </div>
+          )}
         </>
       );
   }

--- a/src/components/panels/Settings.tsx
+++ b/src/components/panels/Settings.tsx
@@ -41,22 +41,16 @@ export function Settings({
           </label>
         </div>
         <div className="flex p-1">
-          <select
-            id="setting-theme"
-            className="h-8"
-            value={settingsData.theme}
+          <input
+            type="checkbox"
+            id="setting-fuzzyDistance"
+            checked={settingsData.fuzzyDistance}
             onChange={(e) =>
-              updateSettings({ theme: e.target.value as "light" | "dark" })
+              updateSettings({ fuzzyDistance: e.target.checked })
             }
-          >
-            <option value="light">Light</option>
-            <option value="dark">Dark</option>
-          </select>
-          <label
-            className="flex-1 ml-2 flex items-center"
-            htmlFor="setting-theme"
-          >
-            {t("settings.theme")}
+          />
+          <label className="flex-1 ml-2" htmlFor="setting-fuzzyDistance">
+            {t("settings.fuzzyDistance")}
           </label>
         </div>
       </div>

--- a/src/domain/geography.ts
+++ b/src/domain/geography.ts
@@ -51,3 +51,17 @@ export function formatDistance(
     ? `${Math.round(distanceInKm).toLocaleString("en-US")} km`
     : `${Math.round(distanceInKm * 0.621371).toLocaleString("en-US")} mi`;
 }
+
+export function formatFuzzyDistance(distanceInMeters: number): string {
+  const distanceInKm = distanceInMeters / 1000;
+
+  if (distanceInKm > 3000) {
+    return "Cold";
+  } else if (distanceInKm > 2000) {
+    return "Lukewarm";
+  } else if (distanceInKm > 1000) {
+    return "Warm";
+  } else {
+    return "Hot";
+  }
+}

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -5,6 +5,7 @@ export interface SettingsData {
   rotationMode: boolean;
   distanceUnit: "km" | "miles";
   theme: "light" | "dark";
+  fuzzyDistance: boolean;
 }
 
 const defaultSettingsData: SettingsData = {
@@ -14,6 +15,7 @@ const defaultSettingsData: SettingsData = {
   theme: window.matchMedia("(prefers-color-scheme: dark)").matches
     ? "dark"
     : "light",
+  fuzzyDistance: false,
 };
 
 function loadSettings(): SettingsData {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -22,6 +22,7 @@ const resources = {
         startingNextDay: "Starting the next day!",
         noImageMode: "Hide country image for more of a challenge.",
         rotationMode: "Randomly rotate country image.",
+        fuzzyDistance: "Show fuzzy distance",
       },
       stats: {
         title: "Statistics",
@@ -54,6 +55,7 @@ const resources = {
         startingNextDay: "A partir du lendemain !",
         noImageMode: "Cache l'image du pays pour plus de challenge.",
         rotationMode: "Tourne l'image du pays de manière aléatoire.",
+        fuzzyDistance: "Afficher la distance floue",
       },
       stats: {
         title: "Statistiques",


### PR DESCRIPTION
In order to avoid game potentially (depending on your geography knowledge) devolving into a regular worldle after a first guess, add a new feature to enable fuzzy distance display. Instead of revealing the exact distance, use terms like "Cold" or "Warm" etc.
