### PR TITLE
fix: dayCount should be the same for users in different timezones

### DIFF
--- a/src/components/Share.tsx
+++ b/src/components/Share.tsx
@@ -36,8 +36,9 @@ export function Share({
   const shareText = useMemo(() => {
     const guessCount =
       guesses[guesses.length - 1]?.distance === 0 ? guesses.length : "X";
+    const endDate = DateTime.fromISO(dayString);
     const dayCount = Math.floor(
-      Interval.fromDateTimes(START_DATE, new Date(dayString)).length("day")
+      Interval.fromDateTimes(START_DATE, endDate).length("day")
     );
     const difficultyModifierEmoji = hideImageMode
       ? " 🙈"


### PR DESCRIPTION
The interval used to compute the day number handles timezones incorrectly. Specifically, the start date is currently constructed by passing a 'yyyy-MM-dd' string to `DateTime.fromISO`. This returns a DateTime that is midnight at the current local time.

However, the end date is constructed as `Interval.fromDateTimes(start, new Date('yyyy-MM-dd'))`. This ends up with a DateTime at midnight UTC on that date (but localized to the current local time).

This means that dayCount can be off by 1 day for users in different timezones, even though they see the same country in the game.

We fix this by correctly constructing both timezones to be midnight in local time.

See example output from the two approaches: https://jsfiddle.net/gpzy63fk/