### PR TITLE
Added OEC links to guesses.

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -40,7 +40,7 @@ interface GameProps {
 export function Game({ settingsData }: GameProps) {
   const { t, i18n } = useTranslation();
   const dayString = useMemo(getDayString, []);
-  const isAprilFools = true; //dayString === "2022-04-01";
+  const isAprilFools = dayString === "2022-04-01";
 
   const countryInputRef = useRef<HTMLInputElement>(null);
 
@@ -110,7 +110,7 @@ export function Game({ settingsData }: GameProps) {
         toast.success(t("welldone"), { delay: 2000 });
       }
     },
-    [addGuess, country, currentGuess, i18n.resolvedLanguage, t, isAprilFools]
+    [addGuess, country, currentGuess, t, isAprilFools]
   );
 
   useEffect(() => {

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -8,11 +8,8 @@ import React, {
 } from "react";
 import { toast } from "react-toastify";
 import {
-  countries,
   getCountryName,
-  sanitizeCountryName,
   countryISOMapping,
-  fictionalCountries,
   getFictionalCountryByName,
   getCountryByName,
 } from "../domain/countries";
@@ -40,7 +37,7 @@ interface GameProps {
 export function Game({ settingsData }: GameProps) {
   const { t, i18n } = useTranslation();
   const dayString = useMemo(getDayString, []);
-  const isAprilFools = true; //dayString === "2022-04-01";
+  const isAprilFools = dayString === "2022-04-01";
 
   const countryInputRef = useRef<HTMLInputElement>(null);
 
@@ -110,7 +107,7 @@ export function Game({ settingsData }: GameProps) {
         toast.success(t("welldone"), { delay: 2000 });
       }
     },
-    [addGuess, country, currentGuess, i18n.resolvedLanguage, t, isAprilFools]
+    [addGuess, country, currentGuess, t, isAprilFools]
   );
 
   useEffect(() => {

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -13,6 +13,8 @@ import {
   sanitizeCountryName,
   countryISOMapping,
   fictionalCountries,
+  getFictionalCountryByName,
+  getCountryByName,
 } from "../domain/countries";
 import { useGuesses } from "../hooks/useGuesses";
 import { CountryInput } from "./CountryInput";
@@ -38,7 +40,7 @@ interface GameProps {
 export function Game({ settingsData }: GameProps) {
   const { t, i18n } = useTranslation();
   const dayString = useMemo(getDayString, []);
-  const isAprilFools = dayString === "2022-04-01";
+  const isAprilFools = true; //dayString === "2022-04-01";
 
   const countryInputRef = useRef<HTMLInputElement>(null);
 
@@ -82,13 +84,9 @@ export function Game({ settingsData }: GameProps) {
         const res = await axios.get("https://geolocation-db.com/json/");
         setIpData(res.data);
       };
-      const items = isAprilFools ? fictionalCountries : countries;
-      const guessedCountry = items.find(
-        (country) =>
-          sanitizeCountryName(
-            getCountryName(i18n.resolvedLanguage, country)
-          ) === sanitizeCountryName(currentGuess)
-      );
+      const guessedCountry = isAprilFools
+        ? getFictionalCountryByName(currentGuess)
+        : getCountryByName(currentGuess);
 
       if (guessedCountry == null) {
         toast.error(t("unknownCountry"));
@@ -99,6 +97,7 @@ export function Game({ settingsData }: GameProps) {
         name: currentGuess,
         distance: geolib.getDistance(guessedCountry, country),
         direction: geolib.getCompassDirection(guessedCountry, country),
+        country: guessedCountry,
       };
 
       addGuess(newGuess);

--- a/src/components/GuessRow.tsx
+++ b/src/components/GuessRow.tsx
@@ -4,7 +4,7 @@ import {
   formatDistance,
   generateSquareCharacters,
 } from "../domain/geography";
-import { Guess } from "../domain/guess";
+import { constructOecLink, Guess } from "../domain/guess";
 import React, { useCallback, useEffect, useState } from "react";
 import CountUp from "react-countup";
 import { SettingsData } from "../hooks/useSettings";
@@ -120,7 +120,12 @@ export function GuessRow({
           </div>
         </>
       );
-    case "ENDED":
+    case "ENDED": {
+      const countrySectionStyle = {
+        display: "flex",
+        justifyContent: "space-between",
+        padding: "16px",
+      };
       return (
         <>
           <div
@@ -129,9 +134,34 @@ export function GuessRow({
                 ? "bg-oec-yellow rounded-lg flex items-center h-8 col-span-3 animate-reveal pl-2"
                 : "bg-gray-200 rounded-lg flex items-center h-8 col-span-3 animate-reveal pl-2"
             }
+            style={countrySectionStyle}
           >
             <p className="text-ellipsis overflow-hidden whitespace-nowrap">
               {getCountryPrettyName(guess?.name, isAprilFools)}
+            </p>
+            <p>
+              {guess?.country !== undefined ? (
+                <a
+                  href={constructOecLink(guess?.country)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    className="h-5 w-5"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    strokeWidth={2}
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+                    />
+                  </svg>
+                </a>
+              ) : null}
             </p>
           </div>
           <div
@@ -175,5 +205,6 @@ export function GuessRow({
           </div>
         </>
       );
+    }
   }
 }

--- a/src/domain/countries.ts
+++ b/src/domain/countries.ts
@@ -2,6 +2,7 @@
 // Countries with long/lat => https://developers.google.com/public-data/docs/canonical/countries_csv
 // Countries images => https://github.com/djaiss/mapsicon
 import { flag } from "country-emoji";
+import i18n from "../i18n";
 
 const countryCodesWithImage = [
   "ad",
@@ -1297,4 +1298,22 @@ export function getCountryPrettyName(
     }
   }
   return `${str}`;
+}
+
+export function getCountryByName(countryName: string): Country | undefined {
+  return countries.find(
+    (country) =>
+      sanitizeCountryName(getCountryName(i18n.resolvedLanguage, country)) ===
+      sanitizeCountryName(countryName)
+  );
+}
+
+export function getFictionalCountryByName(
+  countryName: string
+): Country | undefined {
+  return fictionalCountries.find(
+    (country) =>
+      sanitizeCountryName(getCountryName(i18n.resolvedLanguage, country)) ===
+      sanitizeCountryName(countryName)
+  );
 }

--- a/src/domain/guess.ts
+++ b/src/domain/guess.ts
@@ -1,9 +1,11 @@
+import { Country, countryISOMapping } from "./countries";
 import { Direction } from "./geography";
 
 export interface Guess {
   name: string;
   distance: number;
   direction: Direction;
+  country?: Country;
 }
 
 export function loadAllGuesses(): Record<string, Guess[]> {
@@ -20,4 +22,11 @@ export function saveGuesses(dayString: string, guesses: Guess[]): void {
       [dayString]: guesses,
     })
   );
+}
+
+export function constructOecLink(country: Country) {
+  const country3LetterCode = country?.code
+    ? countryISOMapping[country.code].toLowerCase()
+    : "";
+  return `https://oec.world/en/profile/country/${country3LetterCode}`;
 }


### PR DESCRIPTION
This change allows Tradle players to check the export information from the OEC website for each of their incorrect guesses more easily. 

Note that they'll be able to see the link button even before the game ends. If that's seen as too much information during the game I can guard it to only occur after the game has ended.

**Details:**
- Refactored some country retrieval logic into `getCountryByName` and `getFictionalCountryByName` functions in countries.ts
- Added an optional `country` field to the `Guess` interface. In theory we should be able to just use the country in the guess object and derive all of the other aspects from that country. That can be done in a later PR.
- Created a `constructOecLink(country)` function that finds the 3 letter country code and constructs the link to OEC.
- Change the style of the first section on the `GuessRow` that contains the name to also include a button that goes to the OEC page for the guessed country

Desktop:
<img width="546" alt="Screenshot 2023-09-23 at 2 42 11 PM" src="https://github.com/alexandersimoes/tradle/assets/4380843/08fc3b97-bea3-46da-8516-23408ea58550">
Mobile:
<img width="371" alt="Screenshot 2023-09-23 at 2 42 27 PM" src="https://github.com/alexandersimoes/tradle/assets/4380843/33c30e54-120a-4f84-bf93-a877036b31f0">

