### PR TITLE
Proximity is misleading for very close guesses

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -13,6 +13,7 @@ import {
   getFictionalCountryByName,
   getCountryByName,
 } from "../domain/countries";
+import { getCompassDirection } from "../domain/geography";
 import { useGuesses } from "../hooks/useGuesses";
 import { CountryInput } from "./CountryInput";
 import * as geolib from "geolib";
@@ -93,7 +94,7 @@ export function Game({ settingsData }: GameProps) {
       const newGuess = {
         name: currentGuess,
         distance: geolib.getDistance(guessedCountry, country),
-        direction: geolib.getCompassDirection(guessedCountry, country),
+        direction: getCompassDirection(guessedCountry, country),
         country: guessedCountry,
       };
 

--- a/src/components/GuessRow.tsx
+++ b/src/components/GuessRow.tsx
@@ -12,21 +12,13 @@ import { getCountryPrettyName } from "../domain/countries";
 
 const DIRECTION_ARROWS: Record<Direction, string> = {
   N: "⬆️",
-  NNE: "↗️",
   NE: "↗️",
-  ENE: "↗️",
   E: "➡️",
-  ESE: "↘️",
   SE: "↘️",
-  SSE: "↘️",
   S: "⬇️",
-  SSW: "↙️",
   SW: "↙️",
-  WSW: "↙️",
   W: "⬅️",
-  WNW: "↖️",
   NW: "↖️",
-  NNW: "↖️",
 };
 
 const DIRECTION_ARROWS_APRIL_FOOLS: Record<number, string> = {

--- a/src/domain/geography.ts
+++ b/src/domain/geography.ts
@@ -1,22 +1,9 @@
+import * as geolib from "geolib";
+import { Country } from "./countries";
+
 const MAX_DISTANCE_ON_EARTH = 20_000_000;
 
-export type Direction =
-  | "S"
-  | "W"
-  | "NNE"
-  | "NE"
-  | "ENE"
-  | "E"
-  | "ESE"
-  | "SE"
-  | "SSE"
-  | "SSW"
-  | "SW"
-  | "WSW"
-  | "WNW"
-  | "NW"
-  | "NNW"
-  | "N";
+export type Direction = "S" | "W" | "NE" | "E" | "SE" | "SW" | "NW" | "N";
 
 export function computeProximityPercent(distance: number): number {
   const proximity = Math.max(MAX_DISTANCE_ON_EARTH - distance, 0);
@@ -39,6 +26,38 @@ export function generateSquareCharacters(
   );
 
   return characters;
+}
+
+export function getCompassDirection(
+  guessedCountry: Country,
+  country: Country
+): Direction {
+  const bearing = geolib.getRhumbLineBearing(guessedCountry, country);
+
+  if (isNaN(bearing)) {
+    throw new Error(
+      "Could not calculate bearing for given points. Check your bearing function"
+    );
+  }
+
+  switch (Math.round(bearing / 45)) {
+    case 1:
+      return "NE";
+    case 2:
+      return "E";
+    case 3:
+      return "SE";
+    case 4:
+      return "S";
+    case 5:
+      return "SW";
+    case 6:
+      return "W";
+    case 7:
+      return "NW";
+    default:
+      return "N";
+  }
 }
 
 export function formatDistance(

--- a/src/domain/geography.ts
+++ b/src/domain/geography.ts
@@ -7,7 +7,11 @@ export type Direction = "S" | "W" | "NE" | "E" | "SE" | "SW" | "NW" | "N";
 
 export function computeProximityPercent(distance: number): number {
   const proximity = Math.max(MAX_DISTANCE_ON_EARTH - distance, 0);
-  return Math.round((proximity / MAX_DISTANCE_ON_EARTH) * 100);
+  const rounded = Math.round((proximity / MAX_DISTANCE_ON_EARTH) * 100);
+  if (distance > 0 && rounded >= 100) {
+    return 99;
+  }
+  return rounded;
 }
 
 export function generateSquareCharacters(


### PR DESCRIPTION
In certain cases, when a guessed country is very close to the correct country the proximity is output as 100%.
While this makes sense in a mathematical sense, it doesn't really make sense in a game sense. 

This PR caps any proximity that has a non zero distance to 99%