### PR TITLE
fix: responsive padding to fix mobile bug

### DIFF
--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -188,7 +188,7 @@ export function Game({ settingsData }: GameProps) {
         Guess which country exports these products!
       </h2>
       <div
-        className="relative h-0 pt-[25px] pt-96 md:pb-[70%]"
+        className="relative h-0 pt-[25px] pb-96 md:pb-[70%]"
       >
         {country3LetterCode ? (
           <iframe

--- a/src/components/Game.tsx
+++ b/src/components/Game.tsx
@@ -188,12 +188,7 @@ export function Game({ settingsData }: GameProps) {
         Guess which country exports these products!
       </h2>
       <div
-        style={{
-          position: "relative",
-          paddingBottom: "70%",
-          paddingTop: "25px",
-          height: 0,
-        }}
+        className="relative h-0 pt-[25px] pt-96 md:pb-[70%]"
       >
         {country3LetterCode ? (
           <iframe


### PR DESCRIPTION
**issue:** On mobile the tree map iframe sometimes does not show the popup tip fully. See image below for an example.
![image](https://github.com/alexandersimoes/tradle/assets/7607593/159b0a10-f42e-4885-849c-c9ad06dfb95a)

**fix:** Setting the padding for mobile viewports gives the iframe enough space to fit the tooltip.
![image](https://github.com/alexandersimoes/tradle/assets/7607593/a5e85f25-f6de-4aaf-91ac-a22bb7bd40d1)
